### PR TITLE
Fix and improve code coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,10 @@
+[run]
+branch = True
+source = recitale/
+
+[report]
+exclude_lines =
+    pragma: no cover
+    raise NotImplementedError
+    if __name__ == .__main__.:
+ignore_errors = True

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ recursive-include pics *.png
 include tox.ini
 include LICENSE
 include logo.png
+include .coveragerc
 
 recursive-include docs *.rst
 

--- a/tox.ini
+++ b/tox.ini
@@ -47,4 +47,4 @@ commands = bandit -s B404,B603,B701 -r recitale
 
 [testenv:pytest]
 extras = tests
-commands = pytest --cov --cov-report=xml
+commands = pytest --cov={envsitepackagesdir}/recitale/ --cov-report=xml


### PR DESCRIPTION
This fixes codecov report (currently reporting 100%) and improves the report by enabling branch detection and ignoring common patterns for line and branch exclusions.