### PR TITLE
migrate from path.py to pathlib

### DIFF
--- a/recitale/autogen.py
+++ b/recitale/autogen.py
@@ -4,7 +4,7 @@ import sys
 from time import gmtime, strftime
 from glob import glob
 from jinja2 import Template
-from path import Path
+from pathlib import Path
 from PIL import Image
 
 from .utils import load_settings
@@ -77,7 +77,7 @@ def build_template(folder, force):
         cover=gallery_settings["cover"],
         files=sorted(files_grabbed, key=get_exif),
     )
-    settings = open(Path(".").joinpath(folder, "settings.yaml").abspath(), "w")
+    settings = open(Path(".").joinpath(folder, "settings.yaml").resolve(), "w")
     settings.write(msg)
     logger.info("Generation: %s gallery", folder)
 

--- a/recitale/utils.py
+++ b/recitale/utils.py
@@ -9,7 +9,7 @@ from email.utils import formatdate
 from datetime import datetime
 from builtins import str
 
-from path import Path
+from pathlib import Path
 import ruamel.yaml as yaml
 
 
@@ -142,7 +142,7 @@ def rfc822(date):
 def load_settings(folder):
     try:
         with open(
-            Path(".").joinpath(folder, "settings.yaml").abspath(), "r"
+            Path(".").joinpath(folder, "settings.yaml").resolve(), "r"
         ) as settings:
             gallery_settings = yaml.safe_load(settings.read())
     except (yaml.error.MarkedYAMLError, yaml.YAMLError) as exc:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 Babel
 jinja2
-path.py
 ruamel.yaml
 future
 pillow>=6

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,6 @@ install_requires =
 	future
 	imagesize
 	jinja2
-	path.py
 	pillow >= 6
 	pycryptodomex
 	ruamel.yaml


### PR DESCRIPTION
pathlib is a Python standard library so no additional package is needed.

Also, it's been reported for prosopopee that MacOS users cannot use the
software because of some path.py function being broken so using pathlib
instead seems like a good idea.

See: https://github.com/Psycojoker/prosopopee/issues/124

[WIP] to be properly tested, add unit tests