### PR TITLE
Improve coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,3 +8,4 @@ exclude_lines =
     raise NotImplementedError
     if __name__ == .__main__.:
 ignore_errors = True
+show_missing = True

--- a/test/test_audio.py
+++ b/test/test_audio.py
@@ -54,7 +54,7 @@ class TestAudioFactory:
     def test_same_path_same_audio(self):
         audio1 = AudioFactory.get("gallery", "test.mp3")
         audio2 = AudioFactory.get("gallery", "test.mp3")
-        assert audio1 == audio2
+        assert audio1 is audio2
 
     def test_same_path_same_audio_one_base_audios(self):
         AudioFactory.get("gallery", "test.mp3")
@@ -67,10 +67,10 @@ class TestAudioFactory:
     def test_dotdot_paths(self, gallery, audio):
         audio1 = AudioFactory.get("gallery", "test.mp3")
         audio2 = AudioFactory.get(gallery, audio)
-        assert audio1 == audio2
+        assert audio1 is audio2
 
     def test_base_audios_presence(self):
         audio1 = AudioFactory.get("gallery", "test.mp3")
         base_audios = AudioFactory.base_audios
         assert len(base_audios.keys()) == 1
-        assert audio1 == list(base_audios.values())[0]
+        assert audio1 is list(base_audios.values())[0]

--- a/test/test_image.py
+++ b/test/test_image.py
@@ -1,6 +1,68 @@
 import pytest
 
-from recitale.image import ImageFactory
+from json import dumps as json_dumps
+from unittest.mock import patch
+from zlib import crc32
+
+from recitale.image import BaseImage, ImageFactory
+from recitale.utils import remove_superficial_options
+
+
+class TestBaseImage:
+    @patch("recitale.image.imagesize.get", return_value=(200, 300))
+    def test_first_copy_no_resize(self, mock_imgsz):
+        base = BaseImage({"name": "test.jpg"}, {})
+        base.copy()
+        assert base.copysize == (200, 300)
+
+    @patch("recitale.image.imagesize.get", return_value=(200, 300))
+    def test_two_copies_no_resize(self, mock_imgsz):
+        base = BaseImage({"name": "test.jpg"}, {})
+        base.copy()
+        base.copy()
+        assert len(base.thumbnails.keys()) == 1
+
+    @patch("recitale.image.imagesize.get", return_value=(200, 300))
+    def test_copy_resize(self, mock_imgsz):
+        base = BaseImage({"name": "test.jpg", "resize": "50%"}, {})
+        base.copy()
+        assert base.copysize == (100, 150)
+
+    @patch("recitale.image.imagesize.get", return_value=(200, 300))
+    def test_copy_filepath(self, mock_imgsz):
+        base = BaseImage({"name": "test.jpg", "resize": "50%"}, {})
+        copy = base.copy()
+        assert copy == "test-%s-100x150.jpg" % (
+            crc32(bytes(json_dumps({}, sort_keys=True), "utf-8"))
+        )
+
+    @patch(
+        "recitale.image.remove_superficial_options",
+        side_effect=remove_superficial_options,
+    )
+    @patch("recitale.image.imagesize.get", return_value=(200, 300))
+    def test_copy_filepath_remove_superficial_options(
+        self, mock_imgsz, mock_rm_sup_opt
+    ):
+        base = BaseImage({"name": "test.jpg", "resize": "50%", "test": "test123"}, {})
+        copy = base.copy()
+        mock_rm_sup_opt.called_once_with(
+            {"name": "test.jpg", "resize": "50%", "test": "test123"}
+        )
+        assert copy == "test-%s-100x150.jpg" % (
+            crc32(bytes(json_dumps({"test": "test123"}, sort_keys=True), "utf-8"))
+        )
+
+    @patch("recitale.image.imagesize.get", return_value=(200, 300))
+    def test_copy_invalid_resize(self, mock_imgsz, caplog):
+        base = BaseImage({"name": "test.jpg", "resize": "50"}, {})
+        with pytest.raises(SystemExit) as sysexit:
+            base.copy()
+            assert sysexit.type == SystemExit
+            assert sysexit.value.code == 1
+            assert (
+                caplog.text == "(test.jpg) specified resize setting is not a percentage"
+            )
 
 
 # HACK because ImageFactory.base_imgs does not seem to be reset between tests.

--- a/test/test_image.py
+++ b/test/test_image.py
@@ -31,7 +31,7 @@ class TestImageFactory:
     def test_same_image_with_without_name(self):
         img1 = ImageFactory.get("gallery", "test.jpg")
         img2 = ImageFactory.get("gallery", {"name": "test.jpg"})
-        assert img1 == img2
+        assert img1 is img2
 
     def test_image_dict_without_name(self):
         with pytest.raises(SystemExit) as sysexit:
@@ -42,7 +42,7 @@ class TestImageFactory:
     def test_same_path_same_image(self):
         img1 = ImageFactory.get("gallery", "test.jpg")
         img2 = ImageFactory.get("gallery", "test.jpg")
-        assert img1 == img2
+        assert img1 is img2
 
     def test_same_path_same_image_one_base_imgs(self):
         ImageFactory.get("gallery", "test.jpg")
@@ -55,10 +55,10 @@ class TestImageFactory:
     def test_dotdot_paths(self, gallery, image):
         img1 = ImageFactory.get("gallery", "test.jpg")
         img2 = ImageFactory.get(gallery, image)
-        assert img1 == img2
+        assert img1 is img2
 
     def test_base_imgs_presence(self):
         img1 = ImageFactory.get("gallery", "test.jpg")
         base_imgs = ImageFactory.base_imgs
         assert len(base_imgs.keys()) == 1
-        assert img1 == list(base_imgs.values())[0]
+        assert img1 is list(base_imgs.values())[0]

--- a/test/test_video.py
+++ b/test/test_video.py
@@ -82,7 +82,7 @@ class TestVideoFactory:
     def test_same_path_same_video(self):
         vid1 = VideoFactory.get("gallery", {"name": "test.mp4", "type": "video"})
         vid2 = VideoFactory.get("gallery", {"name": "test.mp4", "type": "video"})
-        assert vid1 == vid2
+        assert vid1 is vid2
 
     def test_same_path_same_video_one_base_vids(self):
         VideoFactory.get("gallery", {"name": "test.mp4", "type": "video"})
@@ -101,10 +101,10 @@ class TestVideoFactory:
     def test_dotdot_paths(self, gallery, video):
         vid1 = VideoFactory.get("gallery", {"name": "test.mp4", "type": "video"})
         vid2 = VideoFactory.get(gallery, video)
-        assert vid1 == vid2
+        assert vid1 is vid2
 
     def test_base_vids_presence(self):
         vid1 = VideoFactory.get("gallery", {"name": "test.mp4", "type": "video"})
         base_vids = VideoFactory.base_vids
         assert len(base_vids.keys()) == 1
-        assert vid1 == list(base_vids.values())[0]
+        assert vid1 is list(base_vids.values())[0]


### PR DESCRIPTION
This improves code coverage and also returns the lines that aren't covered to make it easier to improve coverage over time.

This also fixes an == operator being incorrectly used in lieu of the "is" operator for checking if the returned objects are the same (as in, they are identical, they occupy the same place in memory instead of their content being equal but possibly stored in different locations in memory).