### PR TITLE
Migrate subprocess'ed openssl encryption to pycryptodomex

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -256,6 +256,8 @@ If you want to protect all the website by password::
   title: Gallery
   password: my_super_password
 
+Please note that only the HTML page will be password-protected. Media content such as images, videos and audio files can still be accessed without password if someone knows or guesses their URL inside a password-protected gallery.
+
 Date locale
 ~~~~~~~~~~~
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ path.py
 ruamel.yaml
 future
 pillow>=6
+pycryptodomex
 imagesize
 tqdm

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ install_requires =
 	jinja2
 	path.py
 	pillow >= 6
+	pycryptodomex
 	ruamel.yaml
 	tqdm
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,7 +1,19 @@
 import pytest
+import subprocess
 from unittest.mock import mock_open, patch
 
 import recitale.utils
+
+
+def test_cryptojs_openssl_compatible_encrypt():
+    plaintext = b"this is a test"
+    passphrase = "passphrase"
+    encrypted = recitale.utils.cryptojs_openssl_compatible_encrypt(
+        plaintext, passphrase
+    )
+    openssl = "openssl enc -d -base64 -A -aes-256-cbc -md md5 -pass pass:" + passphrase
+    decrypted = subprocess.check_output(openssl.split(), input=encrypted)
+    assert decrypted == plaintext
 
 
 def test_remove_superficial_options():


### PR DESCRIPTION
This migrates subprocess'ed openssl encryption to pycryptodomex (though still using OpenSSL specific format and key and IV derivation implementation since it's all CryptoJS (the client side decryption tool) knows how to decrypt) and add a small note in the documentation on what not to expect from a password-protected gallery.

This also adds a unit test to make sure the encryption is correct by running subprocess'ed openssl decryption on the encrypted content since we know already CryptoJS knows how to decrypt the same way OpenSSL does.