### PR TITLE
recitale: cast dpi to make it serializable

### DIFF
--- a/recitale/recitale.py
+++ b/recitale/recitale.py
@@ -482,6 +482,9 @@ def image_params(img, options):
         params["quality"] = options["quality"]
     if "dpi" in img.info:
         params["dpi"] = img.info["dpi"]
+        # For following formats, dpi is of type IFDRational which is not serializable
+        if format in ["JPEG", "MPO", "TIFF"]:
+            params["dpi"] = (float(params["dpi"][0]), float(params["dpi"][1]))
     if format == "JPEG" or format == "MPO":
         params["subsampling"] = JpegImagePlugin.get_sampling(img)
 


### PR DESCRIPTION
For Jpeg, MPO and TIFF formats, dpi is of type IFDRational and is thus
not serializable which crashes the cache saving.

This casts the dpi tuple into a float tuple to make it serializable.

Signed-off-by: Quentin Schulz <foss+recitale@0leil.net>