### PR TITLE
Fix crash with Jinja2 >= 3.1

### DIFF
--- a/recitale/recitale.py
+++ b/recitale/recitale.py
@@ -875,7 +875,6 @@ def main():
     theme = settings["settings"].get("theme", "exposure")
     date_locale = settings["settings"].get("date_locale")
     templates = get_gallery_templates(theme, date_locale=date_locale)
-    templates.add_extension("jinja2.ext.with_")
 
     if Path("custom.js").exists():
         shutil.copy(Path("custom.js"), Path(".").joinpath("build", "", "static", "js"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Babel
-jinja2
+jinja2>=2.9
 ruamel.yaml
 future
 pillow>=6

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
 	Babel
 	future
 	imagesize
-	jinja2
+	jinja2 >= 2.9
 	pillow >= 6
 	pycryptodomex
 	ruamel.yaml


### PR DESCRIPTION
Jinja2 removed some deprecated extensions in 3.1 release because they are now built-in. Récitale was still explicitly adding the extensions though it was useless since version 2.9 of Jinja2 and the move from extension to built-in.

This fixes the issue by removing the line and also adding a minimum requirement for Jinja2 version to 2.9 (which was released 2017-01-07) so that this line being removed does not break anything on older (now incompatible) versions.

Fixes #12.