### PR TITLE
Allow filename with spaces and fix video thumbnails in exposure

### DIFF
--- a/recitale/audio.py
+++ b/recitale/audio.py
@@ -61,9 +61,12 @@ class BaseAudio(AudioCommon):
             bytes(json_dumps(self.options, sort_keys=True), "utf-8")
         )
 
+    def _add_reencode(self, reencode):
+        return self.reencodes.setdefault(reencode.filepath, reencode)
+
     def reencode(self):
         reencode = Reencode(self.filepath, self.chksum_opt, self.options["extension"])
-        return self.reencodes.setdefault(reencode.filepath, reencode).filepath.name
+        return self._add_reencode(reencode).filepath.name
 
 
 # TODO: add support for looking into parent directories (name: ../other_gallery/pic.jpg)

--- a/recitale/audio.py
+++ b/recitale/audio.py
@@ -1,6 +1,7 @@
 import logging
 import shlex
 import subprocess
+import urllib.parse
 
 from json import dumps as json_dumps
 from json import loads as json_loads
@@ -66,7 +67,7 @@ class BaseAudio(AudioCommon):
 
     def reencode(self):
         reencode = Reencode(self.filepath, self.chksum_opt, self.options["extension"])
-        return self._add_reencode(reencode).filepath.name
+        return urllib.parse.quote(self._add_reencode(reencode).filepath.name)
 
 
 # TODO: add support for looking into parent directories (name: ../other_gallery/pic.jpg)

--- a/recitale/image.py
+++ b/recitale/image.py
@@ -2,6 +2,7 @@ import imagesize
 import logging
 import re
 import sys
+import urllib.parse
 
 from json import dumps as json_dumps
 from pathlib import Path
@@ -80,7 +81,7 @@ class BaseImage(ImageCommon):
 
     def thumbnail(self, size):
         thumbnail = Thumbnail(self.filepath, self.chksum_opt, size)
-        return self._add_thumbnail(thumbnail).filepath.name
+        return urllib.parse.quote(self._add_thumbnail(thumbnail).filepath.name)
 
 
 # TODO: add support for looking into parent directories (name: ../other_gallery/pic.jpg)

--- a/recitale/image.py
+++ b/recitale/image.py
@@ -75,9 +75,12 @@ class BaseImage(ImageCommon):
 
         return self.thumbnail(self.copysize)
 
+    def _add_thumbnail(self, thumbnail):
+        return self.thumbnails.setdefault(thumbnail.filepath, thumbnail)
+
     def thumbnail(self, size):
         thumbnail = Thumbnail(self.filepath, self.chksum_opt, size)
-        return self.thumbnails.setdefault(thumbnail.filepath, thumbnail).filepath.name
+        return self._add_thumbnail(thumbnail).filepath.name
 
 
 # TODO: add support for looking into parent directories (name: ../other_gallery/pic.jpg)

--- a/recitale/themes/exposure/static/css/style-page.css
+++ b/recitale/themes/exposure/static/css/style-page.css
@@ -347,8 +347,6 @@ padding-bottom: 7em;
   left: 0;
   z-index: 0;
   width: 100%;
-  height: 105%;
-  margin-top: -2%;
 }
 
 .full-picture video {

--- a/recitale/themes/exposure/static/css/style-page.css
+++ b/recitale/themes/exposure/static/css/style-page.css
@@ -93,6 +93,8 @@ a {
 
 .pictures-line .picture img {
   width: 100%;
+  max-height: 100vh;
+  object-fit: contain;
 }
 
 .pictures-line .separator {
@@ -347,6 +349,7 @@ padding-bottom: 7em;
   left: 0;
   z-index: 0;
   width: 100%;
+  max-height: 100vh;
 }
 
 .full-picture video {

--- a/recitale/themes/exposure/static/css/style-page.css
+++ b/recitale/themes/exposure/static/css/style-page.css
@@ -357,9 +357,6 @@ padding-bottom: 7em;
 }
 
 .bordered-picture video {
-  width: 77%;
-  margin-left: 11.5%;
-  margin-right: 11.5%;
   object-fit: fill;
 }
 

--- a/recitale/video.py
+++ b/recitale/video.py
@@ -1,6 +1,7 @@
 import logging
 import shlex
 import subprocess
+import urllib.parse
 
 from json import dumps as json_dumps
 from json import loads as json_loads
@@ -93,14 +94,14 @@ class BaseVideo(VideoCommon):
         reencode = Reencode(
             self.filepath, self.chksum_opt, size, self.options["extension"]
         )
-        return self._add_reencode(reencode).filepath.name
+        return urllib.parse.quote(self._add_reencode(reencode).filepath.name)
 
     def _add_thumbnail(self, thumbnail):
         return self.thumbnails.setdefault(thumbnail.filepath, thumbnail)
 
     def thumbnail(self, size):
         thumbnail = Thumbnail(self.filepath, self.chksum_opt, size)
-        return self._add_thumbnail(thumbnail).filepath.name
+        return urllib.parse.quote(self._add_thumbnail(thumbnail).filepath.name)
 
 
 # TODO: add support for looking into parent directories (name: ../other_gallery/pic.jpg)

--- a/recitale/video.py
+++ b/recitale/video.py
@@ -86,15 +86,21 @@ class BaseVideo(VideoCommon):
             bytes(json_dumps(self.options, sort_keys=True), "utf-8")
         )
 
+    def _add_reencode(self, reencode):
+        return self.reencodes.setdefault(reencode.filepath, reencode)
+
     def reencode(self, size):
         reencode = Reencode(
             self.filepath, self.chksum_opt, size, self.options["extension"]
         )
-        return self.reencodes.setdefault(reencode.filepath, reencode).filepath.name
+        return self._add_reencode(reencode).filepath.name
+
+    def _add_thumbnail(self, thumbnail):
+        return self.thumbnails.setdefault(thumbnail.filepath, thumbnail)
 
     def thumbnail(self, size):
         thumbnail = Thumbnail(self.filepath, self.chksum_opt, size)
-        return self.thumbnails.setdefault(thumbnail.filepath, thumbnail).filepath.name
+        return self._add_thumbnail(thumbnail).filepath.name
 
 
 # TODO: add support for looking into parent directories (name: ../other_gallery/pic.jpg)

--- a/test/test_video.py
+++ b/test/test_video.py
@@ -131,6 +131,13 @@ class TestBaseVideo:
             crc32(bytes(json_dumps({}, sort_keys=True), "utf-8"))
         )
 
+    def test_thumbnail_space_filepath(self):
+        base = BaseVideo({"name": "test with space.mp4"}, {})
+        reenc = base.thumbnail((100, 200))
+        assert reenc == "test%%20with%%20space-%s-100x200.jpg" % (
+            crc32(bytes(json_dumps({}, sort_keys=True), "utf-8"))
+        )
+
 
 # HACK because VideoFactory.base_vids does not seem to be reset between tests.
 @pytest.fixture

--- a/test/test_video.py
+++ b/test/test_video.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from unittest.mock import patch
 from zlib import crc32
 
-from recitale.video import BaseVideo, VideoFactory
+from recitale.video import BaseVideo, VideoFactory, Thumbnail, Reencode
 from recitale.utils import remove_superficial_options
 
 
@@ -79,9 +79,16 @@ class TestBaseVideo:
 
     def test_reencode_same_obj(self):
         base = BaseVideo({"name": "test.mp4", "extension": "webm"}, {})
-        reenc1 = base.reencode((100, 200))
-        reenc2 = base.reencode((100, 200))
+        reencode1 = Reencode(
+            base.filepath, base.chksum_opt, (100, 200), base.options["extension"]
+        )
+        reencode2 = Reencode(
+            base.filepath, base.chksum_opt, (100, 200), base.options["extension"]
+        )
+        reenc1 = base._add_reencode(reencode1)
+        reenc2 = base._add_reencode(reencode2)
         assert len(base.reencodes.keys()) == 1
+        assert reencode1 is not reencode2
         assert reenc1 is reenc2
 
     def test_reencode_diff_resize(self):
@@ -101,9 +108,12 @@ class TestBaseVideo:
 
     def test_thumbnail_same_obj(self):
         base = BaseVideo({"name": "test.mp4"}, {})
-        reenc1 = base.thumbnail((100, 200))
-        reenc2 = base.thumbnail((100, 200))
+        thumbnail1 = Thumbnail(base.filepath, base.chksum_opt, (100, 200))
+        thumbnail2 = Thumbnail(base.filepath, base.chksum_opt, (100, 200))
+        reenc1 = base._add_thumbnail(thumbnail1)
+        reenc2 = base._add_thumbnail(thumbnail2)
         assert len(base.thumbnails.keys()) == 1
+        assert thumbnail1 is not thumbnail2
         assert reenc1 is reenc2
 
     def test_thumbnail_diff_resize(self):

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,8 @@ commands = flake8
 
 [flake8]
 format = pylint
-ignore = W503, E203, E731, E231  # for black compatibility
+# for black compatibility
+ignore = W503, E203, E731, E231
 max-line-length = 100
 exclude = docs/*,.tox/*,.git/*
 


### PR DESCRIPTION
This allows spaces in filenames (notably an issue in exposure theme for bordered-pictures).
This fixes some thumbnails and videos ratio, alignement, size and maximum size issues in exposure theme.