### PR TITLE
Improve pathlib use in autogen

### DIFF
--- a/recitale/autogen.py
+++ b/recitale/autogen.py
@@ -69,7 +69,7 @@ def build_template(folder, force):
         return
 
     for files in types:
-        files_grabbed.extend(glob(Path(".").joinpath(folder, files)))
+        files_grabbed.extend(glob(str(Path(".").joinpath(folder, files))))
     template = Template(DATA, trim_blocks=True)
     msg = template.render(
         title=gallery_settings["title"],

--- a/recitale/autogen.py
+++ b/recitale/autogen.py
@@ -75,8 +75,7 @@ def build_template(folder, force):
         cover=gallery_settings["cover"],
         files=sorted(files_grabbed, key=get_exif),
     )
-    settings = open(Path(".").joinpath(folder, "settings.yaml").resolve(), "w")
-    settings.write(msg)
+    Path(folder).joinpath("settings.yaml").write_text(msg)
     logger.info("Generation: %s gallery", folder)
 
 

--- a/test/test_autogen.py
+++ b/test/test_autogen.py
@@ -1,0 +1,242 @@
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+from tempfile import TemporaryDirectory
+import logging
+
+import recitale.autogen
+
+
+class TestAutogen:
+    @pytest.mark.parametrize("force", [True, False])
+    def test_folder_force(self, force):
+        with patch("recitale.autogen.build_template"):
+            recitale.autogen.autogen(".", force)
+            recitale.autogen.build_template.assert_called_once_with(".", force)
+
+    def test_folder_no_force(self):
+        with patch("recitale.autogen.build_template"):
+            recitale.autogen.autogen(".")
+            recitale.autogen.build_template.assert_called_once_with(".", False)
+
+    def test_all_folders_exclude_root(self):
+        def only_replace_cwd(arg):
+            directory = get_temp_dir() if arg == "." else arg
+            return Path(directory)
+
+        with patch(
+            "recitale.autogen.build_template"
+        ), TemporaryDirectory() as td, patch(
+            "recitale.autogen.Path", side_effect=only_replace_cwd
+        ):
+
+            def get_temp_dir():
+                return td
+
+            root = Path(td).joinpath("settings.yaml")
+            root.touch()
+            recitale.autogen.autogen()
+            assert not any(
+                root in args for args in recitale.autogen.build_template.call_args_list
+            )
+
+    def test_all_folders_exclude_with_subgalleries(self):
+        def only_replace_cwd(arg):
+            directory = get_temp_dir() if arg == "." else arg
+            return Path(directory)
+
+        with patch(
+            "recitale.autogen.build_template"
+        ), TemporaryDirectory() as td, patch(
+            "recitale.autogen.Path", side_effect=only_replace_cwd
+        ):
+
+            def get_temp_dir():
+                return td
+
+            root = Path(td).joinpath("settings.yaml")
+            gallery = Path(td).joinpath("gallery")
+            subgallery = gallery.joinpath("subgallery")
+            subgallery.mkdir(parents=True)
+            gallery_settings = gallery.joinpath("settings.yaml")
+            subgallery_settings = subgallery.joinpath("settings.yaml")
+            root.touch()
+            gallery_settings.touch()
+            subgallery_settings.touch()
+            recitale.autogen.autogen()
+            assert not any(
+                root in args for args in recitale.autogen.build_template.call_args_list
+            )
+            assert not any(
+                gallery_settings in args
+                for args in recitale.autogen.build_template.call_args_list
+            )
+            recitale.autogen.build_template.assert_called_once_with(subgallery, False)
+
+    def test_all_folders_exclude_with_subsubgalleries(self):
+        def only_replace_cwd(arg):
+            directory = get_temp_dir() if arg == "." else arg
+            return Path(directory)
+
+        with patch(
+            "recitale.autogen.build_template"
+        ), TemporaryDirectory() as td, patch(
+            "recitale.autogen.Path", side_effect=only_replace_cwd
+        ):
+
+            def get_temp_dir():
+                return td
+
+            root = Path(td).joinpath("settings.yaml")
+            gallery = Path(td).joinpath("gallery")
+            subgallery = gallery.joinpath("subgallery")
+            subsubgallery = subgallery.joinpath("subsubgallery")
+            subsubgallery.mkdir(parents=True)
+            gallery_settings = gallery.joinpath("settings.yaml")
+            subgallery_settings = subgallery.joinpath("settings.yaml")
+            subsubgallery_settings = subsubgallery.joinpath("settings.yaml")
+            root.touch()
+            gallery_settings.touch()
+            subgallery_settings.touch()
+            subsubgallery_settings.touch()
+            recitale.autogen.autogen()
+            assert not any(
+                root in args for args in recitale.autogen.build_template.call_args_list
+            )
+            assert not any(
+                gallery_settings in args
+                for args in recitale.autogen.build_template.call_args_list
+            )
+            assert not any(
+                subgallery_settings in args
+                for args in recitale.autogen.build_template.call_args_list
+            )
+            recitale.autogen.build_template.assert_called_once_with(
+                subsubgallery, False
+            )
+
+
+class TestBuildTemplate:
+    @patch("recitale.autogen.load_settings", return_value={"static": True})
+    def test_static(self, p, caplog):
+        caplog.set_level(logging.INFO)
+        recitale.autogen.build_template(".", False)
+        assert "Skipped: Nothing to do in" in caplog.text
+
+    @pytest.mark.parametrize(
+        "d",
+        [
+            {},
+            {"title": "test"},
+            {"title": "test", "date": "20230610"},
+            {"title": "test", "cover": "test.jpg"},
+            {"date": "20230610", "cover": "test.jpg"},
+        ],
+    )
+    def test_missing_required_key(self, caplog, d):
+        with pytest.raises(SystemExit) as sysexit, patch(
+            "recitale.autogen.load_settings", return_value=d
+        ):
+            recitale.autogen.build_template(".", False)
+        assert "You need configure first, the title, date and cover in" in caplog.text
+        assert sysexit.type == SystemExit
+        assert sysexit.value.code == 1
+
+    @patch(
+        "recitale.autogen.load_settings",
+        return_value={
+            "title": "test",
+            "cover": "test.jpg",
+            "date": "20230610",
+            "sections": [],
+        },
+    )
+    def test_existing_gallery(self, p, caplog):
+        caplog.set_level(logging.INFO)
+        recitale.autogen.build_template(".", False)
+        assert " gallery is already generated" in caplog.text
+
+    @patch(
+        "recitale.autogen.load_settings",
+        return_value={"title": "test", "cover": "test.jpg", "date": "20230610"},
+    )
+    @patch("recitale.autogen.get_exif", return_value="2023:06:10 10:10:00")
+    @pytest.mark.parametrize("filext", recitale.autogen.types)
+    def test_file_extensions(self, patch_exif, patch_load, filext):
+        with TemporaryDirectory() as td:
+            f = "test" + filext[1:]
+            Path(td).joinpath(f).touch()
+            recitale.autogen.build_template(td, False)
+            generated = Path(td).joinpath("settings.yaml")
+            assert generated.exists()
+            with open(generated) as content:
+                assert (
+                    "".join(content.readlines())
+                    == f"""title: test
+date: 20230610
+cover: test.jpg
+sections:
+  - type: pictures-group
+    images:
+      -
+         - {f}
+"""
+                )
+
+    @patch(
+        "recitale.autogen.load_settings",
+        return_value={
+            "title": "test",
+            "cover": "test.jpg",
+            "date": "20230610",
+            "sections": [],
+        },
+    )
+    @patch("recitale.autogen.get_exif", return_value="2023:06:10 10:10:00")
+    def test_overwrite_existing(self, patch_exif, patch_load):
+        with TemporaryDirectory() as td:
+            f = "test.JPG"
+            Path(td).joinpath(f).touch()
+            recitale.autogen.build_template(td, True)
+            generated = Path(td).joinpath("settings.yaml")
+            assert generated.exists()
+            with open(generated) as content:
+                assert (
+                    "".join(content.readlines())
+                    == """title: test
+date: 20230610
+cover: test.jpg
+sections:
+  - type: pictures-group
+    images:
+      -
+         - test.JPG
+"""
+                )
+
+
+class TestGetExif:
+    @patch("recitale.autogen.os.path.getmtime", return_value=1635362648.7638042)
+    def test_no_exif(self, patched_getmtime):
+        with patch("recitale.autogen.Image.open") as p:
+            p.return_value.getexif.return_value = None
+            assert (
+                recitale.autogen.get_exif("example/first_gallery/stuff.png")
+                == "2021:10:27 19:24:00"
+            )
+
+    @patch("recitale.autogen.os.path.getmtime", return_value=1635362648.7638042)
+    def test_no_datetime_exifs(self, patched_getmtime):
+        assert (
+            recitale.autogen.get_exif("example/first_gallery/stuff.png")
+            == "2021:10:27 19:24:00"
+        )
+
+    @pytest.mark.parametrize("exif", [0x9003, 0x9004, 0x0132])
+    def test_datetime_exifs(self, exif):
+        with patch("recitale.autogen.Image.open") as p:
+            p.return_value.getexif.return_value = {exif: "2023:06:10 10:10:00"}
+            assert (
+                recitale.autogen.get_exif("example/first_gallery/stuff.png")
+                == "2023:06:10 10:10:00"
+            )


### PR DESCRIPTION
Autogen was migrated to pathlib from path.py a while back but it seems not correctly as some issue was reported, c.f. #16.

While at it, replace glob.glob with its pathlib counterpart so we don't have to deal with casts to strings.

Also, close the file descriptor left open by using write_text from pathlib to open, write to and close the file all in one go.

Finally, add unit tests for autogen so we can catch regressions before they happen.