### PR TITLE
fix shlex.quote call on a PosixPath object

### DIFF
--- a/recitale/recitale.py
+++ b/recitale/recitale.py
@@ -753,7 +753,7 @@ def reencode_audio(base):
             logger.info("Skipped: %s is already generated", reencode.filepath)
             return
 
-        command = basecmd + shlex.quote(filepath)
+        command = basecmd + shlex.quote(str(filepath))
         command = command.format(**base.options)
 
         proc = subprocess.Popen(shlex.split(command), stdout=subprocess.PIPE)


### PR DESCRIPTION
`shlex.quote` doesn't like a Path object, it only takes bytes or str objects:

```
    command = basecmd + shlex.quote(filepath)
                        ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/shlex.py", line 329, in quote
    if _find_unsafe(s) is None:
       ^^^^^^^^^^^^^^^
TypeError: expected string or bytes-like object, got 'PosixPath'
```