### PR TITLE
make autogen a bit more auto

### DIFF
--- a/docs/build.rst
+++ b/docs/build.rst
@@ -16,7 +16,7 @@ You need
 1. Create a folder
 2. Put all pics you want
 3. Create settings.yaml file in the folder
-4. Add title and date keys in folder/settings.yaml. Optionally provide a cover key, otherwise it is inferred from the oldest file in the gallery.
+4. Add title key in folder/settings.yaml. Optionally provide a cover and date key, otherwise they are inferred from the oldest file in the gallery.
 5. Use `recitale autogen -d folder`
 
 

--- a/docs/build.rst
+++ b/docs/build.rst
@@ -16,7 +16,7 @@ You need
 1. Create a folder
 2. Put all pics you want
 3. Create settings.yaml file in the folder
-4. Add title, date and cover key in folder/settings.yaml
+4. Add title and date keys in folder/settings.yaml. Optionally provide a cover key, otherwise it is inferred from the oldest file in the gallery.
 5. Use `recitale autogen -d folder`
 
 


### PR DESCRIPTION
As suggested by @crypto512 in https://github.com/recitale/recitale/issues/16#issuecomment-1452628291, let's make autogen a bit smarter by inferring the `date` and `cover` settings from the oldest file in the gallery, when it is missing from the gallery settings.yaml file.

This effectively only makes `title` key a requirement for autogen to work.