### PR TITLE
Fix issues with multiprocessing spawn start method

### DIFF
--- a/recitale/cache.py
+++ b/recitale/cache.py
@@ -16,12 +16,7 @@ logger = logging.getLogger("recitale." + __name__)
 class Cache:
     cache_file_path = os.path.join(os.getcwd(), ".recitale_cache")
 
-    def __init__(self, json):
-        # fix: I need to keep a reference to json because for whatever reason
-        # modules are set to None during python shutdown thus totally breaking
-        # the __del__ call to save the cache
-        # This wonderfully stupid behavior has been fixed in 3.4 (which nobody uses)
-        self.json = json
+    def __init__(self):
         if os.path.exists(os.path.join(os.getcwd(), ".recitale_cache")):
             cache = json.load(open(self.cache_file_path, "r"))
         else:
@@ -77,7 +72,7 @@ class Cache:
         }
 
     def cache_dump(self):
-        self.json.dump(dict(self.cache), open(self.cache_file_path, "w"))
+        json.dump(dict(self.cache), open(self.cache_file_path, "w"))
 
 
-CACHE = Cache(json=json)
+CACHE = Cache()

--- a/recitale/cache.py
+++ b/recitale/cache.py
@@ -73,6 +73,3 @@ class Cache:
 
     def cache_dump(self):
         json.dump(dict(self.cache), open(self.cache_file_path, "w"))
-
-
-CACHE = Cache()

--- a/recitale/recitale.py
+++ b/recitale/recitale.py
@@ -99,14 +99,6 @@ parser_autogen.add_argument(
 )
 
 
-DEFAULTS = {
-    "rss": True,
-    "share": False,
-    "settings": {},
-    "show_date": True,
-    "include": [],
-}
-
 SETTINGS = {
     "gm": {
         "quality": 75,
@@ -146,6 +138,14 @@ class TCPServerV4(socketserver.TCPServer):
 
 
 def get_settings():
+    DEFAULTS = {
+        "rss": True,
+        "share": False,
+        "settings": {},
+        "show_date": True,
+        "include": [],
+    }
+
     settings = load_settings(".")
 
     for key, value in list(DEFAULTS.items()):

--- a/recitale/recitale.py
+++ b/recitale/recitale.py
@@ -43,62 +43,6 @@ def loglevel(string):
     )
 
 
-loglevel_parser = ArgumentParser(add_help=False)
-loglevel_parser.add_argument(
-    "--log-level",
-    default=logging.WARNING,
-    type=loglevel,
-    help="Configure the logging level",
-)
-
-parser = ArgumentParser(
-    description="Static site generator for your story.", parents=[loglevel_parser]
-)
-parser.add_argument("--version", action="version", version="%(prog)s " + __version__)
-
-subparser = parser.add_subparsers(dest="cmd")
-parser_build = subparser.add_parser(
-    "build", help="Generate static site", parents=[loglevel_parser]
-)
-parser_build.add_argument(
-    "-j",
-    "--jobs",
-    default=None,
-    type=int,
-    help="Specifies number of jobs (thumbnail generations) to run simultaneously. Default: number "
-    "of threads available on the system",
-)
-subparser.add_parser(
-    "test", help="Verify all your yaml data", parents=[loglevel_parser]
-)
-subparser.add_parser(
-    "preview", help="Start preview webserver on port 9000", parents=[loglevel_parser]
-)
-subparser.add_parser("deploy", help="Deploy your website", parents=[loglevel_parser])
-parser_autogen = subparser.add_parser(
-    "autogen", help="Generate gallery automaticaly", parents=[loglevel_parser]
-)
-group = parser_autogen.add_mutually_exclusive_group(required=True)
-group.add_argument(
-    "-d",
-    dest="folder",
-    metavar="folder",
-    help="folder to use for automatic gallery generation",
-)
-group.add_argument(
-    "--all",
-    action="store_const",
-    const=None,
-    dest="folder",
-    help="find all folders with settings.yaml for automatic gallery generation",
-)
-parser_autogen.add_argument(
-    "--force",
-    action="store_true",
-    help="**DESTRUCTIVE** force regeneration of gallery even if sections are already defined.",
-)
-
-
 SETTINGS = {
     "gm": {
         "quality": 75,
@@ -811,6 +755,66 @@ logger = logging.getLogger("recitale")
 
 
 def main():
+    loglevel_parser = ArgumentParser(add_help=False)
+    loglevel_parser.add_argument(
+        "--log-level",
+        default=logging.WARNING,
+        type=loglevel,
+        help="Configure the logging level",
+    )
+
+    parser = ArgumentParser(
+        description="Static site generator for your story.", parents=[loglevel_parser]
+    )
+    parser.add_argument(
+        "--version", action="version", version="%(prog)s " + __version__
+    )
+
+    subparser = parser.add_subparsers(dest="cmd")
+    parser_build = subparser.add_parser(
+        "build", help="Generate static site", parents=[loglevel_parser]
+    )
+    parser_build.add_argument(
+        "-j",
+        "--jobs",
+        default=None,
+        type=int,
+        help="Specifies number of jobs (thumbnail generations) to run simultaneously. Default: "
+        "number of threads available on the system",
+    )
+    subparser.add_parser(
+        "test", help="Verify all your yaml data", parents=[loglevel_parser]
+    )
+    subparser.add_parser(
+        "preview",
+        help="Start preview webserver on port 9000",
+        parents=[loglevel_parser],
+    )
+    subparser.add_parser(
+        "deploy", help="Deploy your website", parents=[loglevel_parser]
+    )
+    parser_autogen = subparser.add_parser(
+        "autogen", help="Generate gallery automaticaly", parents=[loglevel_parser]
+    )
+    group = parser_autogen.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "-d",
+        dest="folder",
+        metavar="folder",
+        help="folder to use for automatic gallery generation",
+    )
+    group.add_argument(
+        "--all",
+        action="store_const",
+        const=None,
+        dest="folder",
+        help="find all folders with settings.yaml for automatic gallery generation",
+    )
+    parser_autogen.add_argument(
+        "--force",
+        action="store_true",
+        help="**DESTRUCTIVE** force regeneration of gallery even if sections are already defined.",
+    )
     args = parser.parse_args()
 
     handler = logging.StreamHandler()

--- a/recitale/recitale.py
+++ b/recitale/recitale.py
@@ -104,7 +104,6 @@ DEFAULTS = {
     "share": False,
     "settings": {},
     "show_date": True,
-    "test": False,
     "include": [],
 }
 
@@ -836,9 +835,6 @@ def main():
         )
         sys.exit(1)
 
-    if args.cmd == "test":
-        DEFAULTS["test"] = True
-
     if args.cmd == "preview":
         if not Path("build").exists():
             logger.error("Please build the website before launch preview")
@@ -948,7 +944,7 @@ def main():
 
     build_index(settings, front_page_galleries_cover, templates)
 
-    if DEFAULTS["test"] is True:
+    if args.cmd == "test":
         logger.info("Success: HTML file building without error")
         sys.exit(0)
 

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -10,7 +10,7 @@ from recitale.utils import remove_superficial_options
 
 @pytest.fixture
 def cache():
-    return Cache(json=json)
+    return Cache()
 
 
 class TestCache:
@@ -21,7 +21,7 @@ class TestCache:
     def test_load_cache(self, mock_ospath):
         cache_json = {"version": CACHE_VERSION, "some": "value"}
         with patch("builtins.open", mock_open(read_data=json.dumps(cache_json))):
-            cache = Cache(json=json)
+            cache = Cache()
 
         assert dict(cache.cache) == cache_json
 
@@ -31,7 +31,7 @@ class TestCache:
     )
     def test_load_old_cache(self, mock_ospath, cache_dict):
         with patch("builtins.open", mock_open(read_data=json.dumps(cache_dict))):
-            cache = Cache(json=json)
+            cache = Cache()
 
         assert dict(cache.cache) == {"version": CACHE_VERSION}
 


### PR DESCRIPTION
As reported in #26 , OSes for which `multiprocessing` module uses the `spawn` start method for spawning new processes fails with a RuntimeError.

This attempts at fixing this issue, plus some others that arose while working on it. While at it, let's do some cleaning too.

Note should be taken that OSes other than Linux or `multiprocessing` module configured with anything but the `fork` start method is not officially supported.