### PR TITLE
recitale: fix locale date filter when locale unset

### DIFF
--- a/recitale/recitale.py
+++ b/recitale/recitale.py
@@ -145,7 +145,7 @@ def get_settings():
 
 def get_local_date_filter(date_locale):
     if date_locale is None:
-        date_locale = default_locale("LC_TIME")
+        date_locale = default_locale("LC_TIME") or "en_US_POSIX"
 
     def local_date(value, date_format="dd MMMM yyyy"):
         return format_date(date=value, format=date_format, locale=date_locale)


### PR DESCRIPTION
On systems where neither LC_TIME, LANGUAGE, LC_ALL, LC_CTYPE nor LANG environment variables are set, babel.default_locale('LC_TIME') will return an object of NoneType type which will then fail the babel.format_date() later in the code path.

In order to account for those systems, default to the POSIX locale as is supposed to be the case on POSIX-compliant systems[1].

[1] https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap07.html section 7.2
Reported-by: Sebastien Stormacq <sebastien.stormacq@gmail.com>
Signed-off-by: Quentin Schulz <foss+recitale@0leil.net>