### PR TITLE
themes: exposure: style-page.css: make caption 100% of bordered-picture

### DIFF
--- a/recitale/themes/exposure/static/css/style-page.css
+++ b/recitale/themes/exposure/static/css/style-page.css
@@ -247,11 +247,6 @@ footer a {
   text-align: center;
 }
 
-.bordered-picture .caption__overlay {
-  margin-left: 11.5%;
-  margin-right: 11.5%;
-}
-
 .center, .center-align {
   text-align: center;
 }


### PR DESCRIPTION
The caption is part of a div being 100% of the media to show (be it a video or a picture), therefore adding a right and left margin makes it only take the centered 75% of the media instead of the full width.

The 11.5% are actually applied to the parent parent container. It's a mistake to duplicate it, so let's remove it.