### PR TITLE
themes: exposure: fix video URL covers for subgalleries

### DIFF
--- a/recitale/themes/exposure/templates/index.html
+++ b/recitale/themes/exposure/templates/index.html
@@ -46,9 +46,9 @@
       {% set format = settings.ffmpeg.extension %}
       <div class="gallery-cover">
         <video autoplay loop muted class="fillWidth">
-	  <source src="{{ gallery.link }}/{{ vid }}" type="video/{{ format }}">
+	  <source src="{{ gallery.name }}/{{ vid }}" type="video/{{ format }}">
         </video>
-	<img class="fillWidth" alt="" src="{{ gallery.link }}/{{ video.thumbnail((None, 900)) }}">
+	<img class="fillWidth" alt="" src="{{ gallery.name }}/{{ video.thumbnail((None, 900)) }}">
       </div>
       {% else %}
       {% set cover = Image.get(gallery.link, gallery.cover) %}


### PR DESCRIPTION
In case there's a subgallery with a video as cover, the link is improper as gallery.link provides the absolute path of the subgallery. Considering that all paths here are expected to be relative, this ends up being wrong. Instead, let's use the name of the subgallery instead of its link so that the path relative to the subgallery as returned by vid and video.thumbnail can simply be concatenated with the name to provide the path relative to the current gallery.