### PR TITLE
autogen: include seconds in date format

### DIFF
--- a/recitale/autogen.py
+++ b/recitale/autogen.py
@@ -33,7 +33,7 @@ logger = logging.getLogger("recitale." + __name__)
 
 types = ("*.JPG", "*.jpg", "*.JPEG", "*.jpeg", "*.png", "*.PNG")
 
-TIME_FORMAT = "%Y:%m:%d %H:%M:00"
+TIME_FORMAT = "%Y:%m:%d %H:%M:%S"
 
 
 def get_exif(filename):

--- a/test/test_autogen.py
+++ b/test/test_autogen.py
@@ -150,7 +150,7 @@ class TestBuildTemplate:
         "recitale.autogen.load_settings",
         return_value={"title": "test", "cover": "test.jpg"},
     )
-    @patch("recitale.autogen.get_exif", return_value="2023:06:10 10:10:00")
+    @patch("recitale.autogen.get_exif", return_value="2023:06:10 10:10:10")
     def test_missing_date(self, patch_exif, patch_load):
         with TemporaryDirectory() as td:
             f = "test.png"
@@ -176,7 +176,7 @@ sections:
         "recitale.autogen.load_settings",
         return_value={"title": "test", "date": "20230610"},
     )
-    @patch("recitale.autogen.get_exif", return_value="2023:06:10 10:10:00")
+    @patch("recitale.autogen.get_exif", return_value="2023:06:10 10:10:10")
     def test_missing_cover(self, patch_exif, patch_load):
         with TemporaryDirectory() as td:
             f = "test.png"
@@ -204,7 +204,7 @@ sections:
     )
     @patch(
         "recitale.autogen.get_exif",
-        side_effect=["2023:06:10 10:10:00", "2016:10:08 01:01:00"],
+        side_effect=["2023:06:10 10:10:10", "2016:10:08 01:01:01"],
     )
     def test_missing_cover_oldest_picked(self, patch_exif, patch_load):
         with TemporaryDirectory() as td:
@@ -234,7 +234,7 @@ sections:
         "recitale.autogen.load_settings",
         return_value={"title": "test", "cover": "test.jpg", "date": "20230610"},
     )
-    @patch("recitale.autogen.get_exif", return_value="2023:06:10 10:10:00")
+    @patch("recitale.autogen.get_exif", return_value="2023:06:10 10:10:10")
     @pytest.mark.parametrize("filext", recitale.autogen.types)
     def test_file_extensions(self, patch_exif, patch_load, filext):
         with TemporaryDirectory() as td:
@@ -266,7 +266,7 @@ sections:
             "sections": [],
         },
     )
-    @patch("recitale.autogen.get_exif", return_value="2023:06:10 10:10:00")
+    @patch("recitale.autogen.get_exif", return_value="2023:06:10 10:10:10")
     def test_overwrite_existing(self, patch_exif, patch_load):
         with TemporaryDirectory() as td:
             f = "test.JPG"
@@ -309,8 +309,8 @@ class TestGetExif:
     @pytest.mark.parametrize("exif", [0x9003, 0x9004, 0x0132])
     def test_datetime_exifs(self, exif):
         with patch("recitale.autogen.Image.open") as p:
-            p.return_value.getexif.return_value = {exif: "2023:06:10 10:10:00"}
+            p.return_value.getexif.return_value = {exif: "2023:06:10 10:10:10"}
             assert (
                 recitale.autogen.get_exif("example/first_gallery/stuff.png")
-                == "2023:06:10 10:10:00"
+                == "2023:06:10 10:10:10"
             )

--- a/test/test_autogen.py
+++ b/test/test_autogen.py
@@ -296,14 +296,14 @@ class TestGetExif:
             p.return_value.getexif.return_value = None
             assert (
                 recitale.autogen.get_exif("example/first_gallery/stuff.png")
-                == "2021:10:27 19:24:00"
+                == "2021:10:27 19:24:08"
             )
 
     @patch("recitale.autogen.os.path.getmtime", return_value=1635362648.7638042)
     def test_no_datetime_exifs(self, patched_getmtime):
         assert (
             recitale.autogen.get_exif("example/first_gallery/stuff.png")
-            == "2021:10:27 19:24:00"
+            == "2021:10:27 19:24:08"
         )
 
     @pytest.mark.parametrize("exif", [0x9003, 0x9004, 0x0132])


### PR DESCRIPTION
TIME_FORMAT is used both for encoding and decoding a date. If a media file doesn't contain an exif field for the date, it'll be provided one from the mtime, itself encoded via TIME_FORMAT. However if a media file does contain an exif field for the date, then it'll be used without going through the encoding part. Therefore, the decoding should take into account that the seconds part of the date can be something else than 00.

This fixes autogen for files with an exif date field where the seconds part was non-zero.

Fixes: 5e525a5d0750 ("autogen: autofill date gallery setting if missing")