### PR TITLE
autogen: improve error handling

### DIFF
--- a/recitale/autogen.py
+++ b/recitale/autogen.py
@@ -88,6 +88,18 @@ def build_template(folder, force):
 
 def autogen(folder=None, force=False):
     if folder:
+        if not Path(folder).exists():
+            logger.error("%s directory does not exist", folder)
+            return
+
+        if not Path(folder).is_dir():
+            logger.error("%s must be a directory", folder)
+            return
+
+        if not Path(folder).joinpath("settings.yaml").exists():
+            logger.error("%s directory must contain a settings.yaml", folder)
+            return
+
         build_template(folder, force)
         return
 


### PR DESCRIPTION
Providing a path to a directory without a settings.yaml complains that the file doesn't exist but it isn't very explicit what one should do, so let's improve that.

While at it, handle non-existing paths or paths that aren't directories.