### PR TITLE
test: autogen: make test_missing_cover_oldest_picked deterministic

### DIFF
--- a/test/test_autogen.py
+++ b/test/test_autogen.py
@@ -198,13 +198,18 @@ sections:
 """
                 )
 
+    def side_effect_oldest_picked(*args, **kwargs):
+        if args[0].name == "test.png":
+            return "2023:06:10 10:10:10"
+        return "2016:10:08 01:01:01"
+
     @patch(
         "recitale.autogen.load_settings",
         return_value={"title": "test", "date": "20230610"},
     )
     @patch(
         "recitale.autogen.get_exif",
-        side_effect=["2023:06:10 10:10:10", "2016:10:08 01:01:01"],
+        side_effect=side_effect_oldest_picked,
     )
     def test_missing_cover_oldest_picked(self, patch_exif, patch_load):
         with TemporaryDirectory() as td:


### PR DESCRIPTION
This test mocked calls to get_exif() functions and replaced the return value of the first call with one value and the return value of the second call with another value.

The issue is that the code calling this function is used for ordering a list of filepaths. In itself that is fine. However, this list of filepaths is collected with pathlib.glob(). While pathlib.glob() doesn't make this explicit, if it works the same way glob.glob()[1] works, the output is non-deterministic. This means that the outcome of this test was unreliable, which was seen on GitHub CI (but not always) but not locally.

To make this test deterministic, mock the return value but only depending on the argument, so that regardless of the order get_exif() gets called, it will always return the appropriate value.

[1] https://docs.python.org/3/library/glob.html "results are returned in arbitrary order"
Fixes: 5e525a5d0750 "autogen: autofill date gallery setting if missing"
Signed-off-by: Quentin Schulz <foss+recitale@0leil.net>