### PR TITLE
containers: bump base debian image to bookworm

### DIFF
--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -1,4 +1,4 @@
-from python:slim-bullseye
+from python:slim-bookworm
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y ffmpeg
 


### PR DESCRIPTION
Bookworm was released in June 2023, it's time to migrate to it to benefit from newer ffmpeg and various security and bug fixes.