### PR TITLE
test: test_cache: reduce scope of open builtin patch

### DIFF
--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -20,7 +20,7 @@ class TestCache:
     @patch("recitale.cache.os.path.exists", return_value=True)
     def test_load_cache(self, mock_ospath):
         cache_json = {"version": CACHE_VERSION, "some": "value"}
-        with patch("builtins.open", mock_open(read_data=json.dumps(cache_json))):
+        with patch("recitale.cache.open", mock_open(read_data=json.dumps(cache_json))):
             cache = Cache()
 
         assert dict(cache.cache) == cache_json
@@ -30,13 +30,13 @@ class TestCache:
         "cache_dict", [{"version": CACHE_VERSION + 1}, {"some": "value"}]
     )
     def test_load_old_cache(self, mock_ospath, cache_dict):
-        with patch("builtins.open", mock_open(read_data=json.dumps(cache_dict))):
+        with patch("recitale.cache.open", mock_open(read_data=json.dumps(cache_dict))):
             cache = Cache()
 
         assert dict(cache.cache) == {"version": CACHE_VERSION}
 
     def test_dump_cache(self, cache):
-        with patch("builtins.open", mock_open()) as p:
+        with patch("recitale.cache.open", mock_open()) as p:
             cache.cache_dump()
 
         p.assert_called_with(os.path.join(os.getcwd(), ".recitale_cache"), "w")


### PR DESCRIPTION
Currently all builtin open calls are patched but this seems to trip multiprocessing.Manager spawning on Python 3.14+ when calling reduction.pickle.load() in spawn.py[1]. I'm unsure why as this line has been there for 10+ years).

In any case, this was a hammer approach to patching the two open() calls in recitale/cache.py so let's instead explicitly patch those two only.

This fixes running the pytest test suite on Python 3.14+.

[1] https://github.com/python/cpython/blob/v3.14.2/Lib/multiprocessing/spawn.py#L130