### PR TITLE
Fix error message when selected theme doesn't exist

### DIFF
--- a/recitale/recitale.py
+++ b/recitale/recitale.py
@@ -157,15 +157,13 @@ def get_gallery_templates(
     theme, gallery_path="", parent_templates=None, date_locale=None
 ):
     themes_dir = Path(__file__).parent.joinpath("themes")
-    theme_path = themes_dir.joinpath(theme).exists()
 
     available_themes = theme, "', '".join(str(path) for path in themes_dir.iterdir())
 
-    if not theme_path:
+    if not themes_dir.joinpath(theme).exists():
         logger.error(
             "'%s' is not an existing theme + available themes are '%s'",
-            theme_path,
-            available_themes,
+            *available_themes,
         )
         sys.exit(1)
 

--- a/recitale/recitale.py
+++ b/recitale/recitale.py
@@ -156,11 +156,10 @@ def get_local_date_filter(date_locale):
 def get_gallery_templates(
     theme, gallery_path="", parent_templates=None, date_locale=None
 ):
-    theme_path = Path(__file__).parent.joinpath("themes", theme).exists()
+    themes_dir = Path(__file__).parent.joinpath("themes")
+    theme_path = themes_dir.joinpath(theme).exists()
 
-    available_themes = theme, "', '".join(
-        str(path) for path in Path(__file__).parent.joinpath("themes").iterdir()
-    )
+    available_themes = theme, "', '".join(str(path) for path in themes_dir.iterdir())
 
     if not theme_path:
         logger.error(
@@ -172,13 +171,11 @@ def get_gallery_templates(
 
     templates_dir = [
         Path(".").joinpath("templates").resolve(),
-        Path(__file__).parent.joinpath("themes", theme, "templates"),
+        themes_dir.joinpath(theme, "templates"),
     ]
 
     if theme != "exposure":
-        templates_dir.append(
-            Path(__file__).parent.joinpath("themes", "exposure", "templates")
-        )
+        templates_dir.append(themes_dir.joinpath("exposure", "templates"))
 
     subgallery_templates = Environment(
         loader=FileSystemLoader(templates_dir), trim_blocks=True
@@ -202,7 +199,7 @@ def get_gallery_templates(
 
     else:
         shutil.copytree(
-            Path(__file__).parent.joinpath("themes", theme, "static"),
+            themes_dir.joinpath(theme, "static"),
             Path(".").joinpath("build", gallery_path, "static"),
         )
 

--- a/recitale/recitale.py
+++ b/recitale/recitale.py
@@ -158,12 +158,13 @@ def get_gallery_templates(
 ):
     themes_dir = Path(__file__).parent.joinpath("themes")
 
-    available_themes = theme, "', '".join(str(path) for path in themes_dir.iterdir())
-
     if not themes_dir.joinpath(theme).exists():
+        themes = [path.name for path in themes_dir.iterdir() if path.is_dir()]
+
         logger.error(
-            "'%s' is not an existing theme + available themes are '%s'",
-            *available_themes,
+            "%s is not a valid theme. Available themes are: %s",
+            theme,
+            ", ".join(sorted(themes)),
         )
         sys.exit(1)
 


### PR DESCRIPTION
I made a mistake in dbd8fc8c07f7 ("prosopopee: add missing argument to logging message") because `available_themes` is actually a tuple, so it was in fact NOT missing an argument, I just got confused.

This makes things tidier by using (properly named) variables only if required, stopping to use a tuple as argument and rewording the error message.