### PR TITLE
Bump container to Trixie

### DIFF
--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -1,6 +1,6 @@
-from python:slim-bookworm
+FROM python:slim-trixie
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y ffmpeg
+RUN DEBIAN_FRONTEND=noninteractive apt-get install --update --no-install-recommends -y ffmpeg
 
 ARG VERSION
 

--- a/recitale/recitale.py
+++ b/recitale/recitale.py
@@ -628,7 +628,7 @@ def render_video(cache, base):
                 bar_format="{l_bar}{bar}| {n_fmt}s/{total_fmt}s | ETA: {remaining}",
             ) as pbar:
                 for content in proc.stdout:
-                    m = re.search(r"out_time_us=(.*)\\n", str(content))
+                    m = re.search(r"out_time_us=(\d+)\\n", str(content))
                     if m and m.group(1):
                         us = int(m.group(1))
                         reencoded_secs = us // 1000000
@@ -716,7 +716,7 @@ def reencode_audio(cache, base):
             bar_format="{l_bar}{bar}| {n_fmt}s/{total_fmt}s | ETA: {remaining}",
         ) as pbar:
             for content in proc.stdout:
-                m = re.search(r"out_time_us=(.*)\\n", str(content))
+                m = re.search(r"out_time_us=(\d+)\\n", str(content))
                 if m and m.group(1):
                     us = int(m.group(1))
                     reencoded_secs = us // 1000000

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -20,7 +20,7 @@ class TestCache:
     @patch("recitale.cache.os.path.exists", return_value=True)
     def test_load_cache(self, mock_ospath):
         cache_json = {"version": CACHE_VERSION, "some": "value"}
-        with patch("builtins.open", mock_open(read_data=json.dumps(cache_json))):
+        with patch("recitale.cache.open", mock_open(read_data=json.dumps(cache_json))):
             cache = Cache()
 
         assert dict(cache.cache) == cache_json
@@ -30,13 +30,13 @@ class TestCache:
         "cache_dict", [{"version": CACHE_VERSION + 1}, {"some": "value"}]
     )
     def test_load_old_cache(self, mock_ospath, cache_dict):
-        with patch("builtins.open", mock_open(read_data=json.dumps(cache_dict))):
+        with patch("recitale.cache.open", mock_open(read_data=json.dumps(cache_dict))):
             cache = Cache()
 
         assert dict(cache.cache) == {"version": CACHE_VERSION}
 
     def test_dump_cache(self, cache):
-        with patch("builtins.open", mock_open()) as p:
+        with patch("recitale.cache.open", mock_open()) as p:
             cache.cache_dump()
 
         p.assert_called_with(os.path.join(os.getcwd(), ".recitale_cache"), "w")


### PR DESCRIPTION
This bumps the container to Trixie. Two small fixes are necessary before doing so:
- since this new Trixie container has Python 3.14, #54 is required,
- for some reason ffmpeg returns N/A for the first `out_time_us` instead of a number, so we need to ignore that