### PR TITLE
.github: workflows: devel: re-add fetch-tags

### DIFF
--- a/.github/workflows/devel.yml
+++ b/.github/workflows/devel.yml
@@ -9,6 +9,8 @@ jobs:
       SETUPTOOLS_SCM_OVERRIDES_FOR_RECITALE: '{local_scheme = "no-local-version"}'
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-tags: true
       - uses: actions/setup-python@v6
         with:
           python-version: '3.x'


### PR DESCRIPTION
Definitely needed otherwise the sdist is generated with 0.1dev1 as version, as highlighted in Test PyPI[1] and job history[2].

[1] https://test.pypi.org/manage/project/recitale/release/0.1.dev1/
[2] https://github.com/recitale/recitale/actions/runs/21679175587/job/62508242585#step:5:46