### PR TITLE
.github: workflows: devel: fetch the last 999 commits

### DIFF
--- a/.github/workflows/devel.yml
+++ b/.github/workflows/devel.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          fetch-depth: 999
           fetch-tags: true
       - uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
Otherwise setuptools_scm won't be able to derive the version number for the sdist to upload to Test PyPI. It shouldn't be an issue for the release build as the commit will be the tagged one, so hopefully fetch-tags is enough there. We'll know soon once I do a releae :)