### PR TITLE
Misc cosmetic/docs changes 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<img src="logo.png">
+<img width="140px" src="recitale/themes/exposure/static/img/logo.svg">
 </p>
 
 ![GitHub](https://img.shields.io/github/license/recitale/recitale?color=brightgreen)

--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -3,7 +3,7 @@ Authors
 
 By chronological order:
 
- * Bram, launched the project
+ * Bram, launched the prosopopée project
  * Kload
  * opi
  * taziden
@@ -13,3 +13,8 @@ By chronological order:
  * Titoko
  * 0x010C
  * QSchulz
+ * treellama
+ * thatch
+ * eugeneandrienko
+ * angelop
+ * crypto512

--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -18,3 +18,8 @@ By chronological order:
  * eugeneandrienko
  * angelop
  * crypto512
+
+New contributors since recitale forked prosopopée, by chronological order:
+
+ * jboursier
+ * sebsto

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -100,7 +100,6 @@ recitale can use ffmpeg or libav and each can be configured if needed::
       binary: "ffmpeg"
       loglevel: "error"
       format: "webm"
-      resolution: "1280x720"
       vbitrate: "3900k"
       abitrate: "100k"
       audio: "libvorbis"
@@ -112,7 +111,6 @@ The meaning of the currently supported FFMPEG or LIBAV's settings is as follows:
  * `binary` sets the binary to use to convert the video (ffmpeg or avconv)
  * `loglevel` sets the logging level used by the library
  * `format` forces input or output file format
- * `resolution` sets frame size
  * `vbitrate` sets video bitrate
  * `abitrate` sets audio bitrate
  * `audio` sets the audio codec

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,6 @@ You can find example usages here:
  * https://media.faimaison.net/photos/galerie/
  * https://www.thebrownianmovement.org/
  * https://outside.browny.pink
- * http://www.street-art.me
 
 Why
 ===

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ You can find example usages here:
  * https://media.faimaison.net/photos/galerie/
  * https://www.thebrownianmovement.org/
  * https://outside.browny.pink
+ * https://pictures.0leil.net
 
 Why
 ===

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ You can find example usages here:
 Why
 ===
 
-I wanted to learn a bit of advanced css and I wanted to self-host my data instead of using exposure.co.
+According to its creator, `prosopopee <https://github.com/Psycojoker/prosopopee>`__ was originally created as they "wanted to learn a bit of advanced css and wanted to self-host data instead of using exposure.co".
 
 Licence
 =======

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -11,11 +11,11 @@ We need Python, pip and virtualenv::
 
     apt-get install python3-pip python3-virtualenv
 
-And a video converter like ffmpeg::
+If you plan on sharing video or audio files, we also need ffmpeg::
 
     apt-get install ffmpeg
 
-For deployment, we need rsync::
+If you plan on using recitale for uploading the generated website, we additionally need rsync::
   
     apt-get install rsync
 
@@ -26,11 +26,11 @@ We need Brew::
 
   /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
-And a video converter like ffmpeg::
+If you plan on sharing video or audio files, we also need ffmpeg::
   
   brew install ffmpeg
 
-For deployment, we need rsync::
+If you plan on using recitale for uploading the generated website, we additionally need rsync::
 
   brew install rsync
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -15,10 +15,6 @@ And a video converter like ffmpeg::
 
     apt-get install ffmpeg
 
-or::
-
-    apt-get install libav-tools
-
 For deployment, we need rsync::
   
     apt-get install rsync

--- a/recitale/recitale.py
+++ b/recitale/recitale.py
@@ -55,7 +55,6 @@ SETTINGS = {
         "binary": "ffmpeg",
         "loglevel": "error",
         "format": "webm",
-        "resolution": "1280x720",
         "vbitrate": "3900k",
         "abitrate": "100k",
         "audio": "libvorbis",

--- a/recitale/recitale.py
+++ b/recitale/recitale.py
@@ -69,6 +69,10 @@ SETTINGS = {
         "audio": "libmp3lame",
         "extension": "mp3",
     },
+    "licence": {
+        "name": "CC-BY-SA-3.0",
+        "url": "https://creativecommons.org/licenses/by-sa/3.0/",
+    },
 }
 
 

--- a/recitale/themes/exposure/templates/footer.html
+++ b/recitale/themes/exposure/templates/footer.html
@@ -1,13 +1,6 @@
-{% if settings.licence is not defined %}
-{% set licence_url = 'https://creativecommons.org/licenses/by-sa/3.0/' %}
-{% set licence_name = 'CC-BY-SA-3.0' %}
-{% else %}
-{% set licence_url = settings.licence.url %}
-{% set licence_name = settings.licence.name %}
-{% endif %}
 {% if settings.custom_js %}
 <script type="text/javascript" src="../static/js/custom.js" charset="utf-8"></script>
 {% endif %}
 <footer>
-  <p>Generated using <a href="https://github.com/recitale/recitale">recitale</a> · content under <a href="{{ licence_url }}">{{ licence_name }}</a> · atom logo by <a href="https://thenounproject.com/jjjon/">Jonathan Li</a> under <a href="https://creativecommons.org/licenses/by/3.0/">CC-BY</a></p>
+  <p>Generated using <a href="https://github.com/recitale/recitale">recitale</a> · content under <a href="{{ settings.licence.url }}">{{ settings.licence.name }}</a> · atom logo by <a href="https://thenounproject.com/jjjon/">Jonathan Li</a> under <a href="https://creativecommons.org/licenses/by/3.0/">CC-BY</a></p>
 </footer>

--- a/recitale/themes/exposure/templates/footer.html
+++ b/recitale/themes/exposure/templates/footer.html
@@ -1,6 +1,6 @@
 {% if settings.licence is not defined %}
 {% set licence_url = 'https://creativecommons.org/licenses/by-sa/3.0/' %}
-{% set licence_name = 'CC-BY-SA' %}
+{% set licence_name = 'CC-BY-SA-3.0' %}
 {% else %}
 {% set licence_url = settings.licence.url %}
 {% set licence_name = settings.licence.name %}

--- a/recitale/themes/exposure/templates/footer.html
+++ b/recitale/themes/exposure/templates/footer.html
@@ -2,5 +2,5 @@
 <script type="text/javascript" src="../static/js/custom.js" charset="utf-8"></script>
 {% endif %}
 <footer>
-  <p>Generated using <a href="https://github.com/recitale/recitale">recitale</a> · content under <a href="{{ settings.licence.url }}">{{ settings.licence.name }}</a> · atom logo by <a href="https://thenounproject.com/jjjon/">Jonathan Li</a> under <a href="https://creativecommons.org/licenses/by/3.0/">CC-BY</a></p>
+  <p>Generated using <a href="https://github.com/recitale/recitale">recitale</a> · content under <a href="{{ settings.licence.url }}">{{ settings.licence.name }}</a> · "atom" logo by Jonathan Li from <a href="https://thenounproject.com/browse/icons/term/atom/">Noun Project</a> CC BY 3.0</p>
 </footer>

--- a/recitale/themes/light/templates/footer.html
+++ b/recitale/themes/light/templates/footer.html
@@ -1,11 +1,4 @@
-{% if settings.licence is not defined %}
-{% set licence_url = 'https://creativecommons.org/licenses/by-sa/3.0/' %}
-{% set licence_name = 'CC-BY-SA-3.0' %}
-{% else %}
-{% set licence_url = settings.licence.url %}
-{% set licence_name = settings.licence.name %}
-{% endif %}
 
 <footer>
-    <p>Generated using <a href="https://github.com/recitale/recitale">recitale</a> · content under <a href="{{ licence_url }}">{{ licence_name }}</a> · atom logo by <a href="https://thenounproject.com/jjjon/">Jonathan Li</a> under <a href="https://creativecommons.org/licenses/by/3.0/">CC-BY</a></p>
+    <p>Generated using <a href="https://github.com/recitale/recitale">recitale</a> · content under <a href="{{ settings.licence.url }}">{{ settings.licence.name }}</a> · atom logo by <a href="https://thenounproject.com/jjjon/">Jonathan Li</a> under <a href="https://creativecommons.org/licenses/by/3.0/">CC-BY</a></p>
 </footer>

--- a/recitale/themes/light/templates/footer.html
+++ b/recitale/themes/light/templates/footer.html
@@ -1,4 +1,4 @@
 
 <footer>
-    <p>Generated using <a href="https://github.com/recitale/recitale">recitale</a> · content under <a href="{{ settings.licence.url }}">{{ settings.licence.name }}</a> · atom logo by <a href="https://thenounproject.com/jjjon/">Jonathan Li</a> under <a href="https://creativecommons.org/licenses/by/3.0/">CC-BY</a></p>
+    <p>Generated using <a href="https://github.com/recitale/recitale">recitale</a> · content under <a href="{{ settings.licence.url }}">{{ settings.licence.name }}</a> · "atom" logo by Jonathan Li from <a href="https://thenounproject.com/browse/icons/term/atom/">Noun Project</a> CC BY 3.0</p>
 </footer>

--- a/recitale/themes/light/templates/footer.html
+++ b/recitale/themes/light/templates/footer.html
@@ -1,6 +1,6 @@
 {% if settings.licence is not defined %}
 {% set licence_url = 'https://creativecommons.org/licenses/by-sa/3.0/' %}
-{% set licence_name = 'CC-BY-SA' %}
+{% set licence_name = 'CC-BY-SA-3.0' %}
 {% else %}
 {% set licence_url = settings.licence.url %}
 {% set licence_name = settings.licence.name %}


### PR DESCRIPTION
This makes recitale provide a default license instead of relying on the theme to provide one.

This adds contributors to the list in the docs (I won't promise I'll keep this updated).

This replaces a dead link with my website.

This fixes a few things in the docs like non-applicable settings, rewording dependency "requirements",.

This fixes the attribution for the logo as specified from the website it originally comes from.

This uses an SVG logo instead of PNG in the README.