### PR TITLE
Fix cache misses, improper image and video ratio and not resizing on Image.copy()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
 ]
 dependencies = [
 	"Babel",
-	"imagesize",
 	"jinja2 >= 2.9",
 	"pillow >= 6",
 	"pycryptodomex",

--- a/recitale/image.py
+++ b/recitale/image.py
@@ -1,4 +1,3 @@
-import imagesize
 import logging
 import re
 import sys
@@ -6,6 +5,7 @@ import urllib.parse
 
 from json import dumps as json_dumps
 from pathlib import Path
+from PIL import Image
 from zlib import crc32
 
 from .utils import remove_superficial_options
@@ -14,17 +14,7 @@ from .utils import remove_superficial_options
 logger = logging.getLogger("recitale." + __name__)
 
 
-class ImageCommon:
-    @property
-    def ratio(self):
-        # For when BaseImage.ratio is called before BaseImage.copy() is.
-        if not hasattr(self, "size"):
-            self.size = imagesize.get(self.filepath)
-        width, height = self.size
-        return width / height
-
-
-class Thumbnail(ImageCommon):
+class Thumbnail:
     def __init__(self, base_filepath, base_id, size):
         self.filepath = self.__filepath(base_filepath, base_id, size)
         self.size = size
@@ -42,10 +32,11 @@ class Thumbnail(ImageCommon):
         return p.parent / (p.stem + suffix)
 
 
-class BaseImage(ImageCommon):
+class BaseImage:
     re_rsz = re.compile(r"^(\d+)%$")
 
     def __init__(self, options, global_options):
+        # Rotation applied to self.size, self.copysize dimensions already
         self.copysize = None
         self.thumbnails = dict()
         self.options = global_options.copy()
@@ -59,11 +50,9 @@ class BaseImage(ImageCommon):
 
     def copy(self):
         if not self.copysize:
-            # No need to get image size if .ratio() was called before .copy()
-            if not hasattr(self, "size"):
-                self.size = imagesize.get(self.filepath)
-
+            self._init_size()
             width, height = self.size
+
             if self.resize:
                 match = BaseImage.re_rsz.match(str(self.resize))
                 if not match:
@@ -85,6 +74,32 @@ class BaseImage(ImageCommon):
     def thumbnail(self, size):
         thumbnail = Thumbnail(self.filepath, self.chksum_opt, size)
         return urllib.parse.quote(self._add_thumbnail(thumbnail).filepath.name)
+
+    @property
+    def ratio(self):
+        self._init_size()
+
+        return self.size[0] / self.size[1]
+
+    def _init_size(self):
+        if hasattr(self, "size"):
+            return
+
+        im = Image.open(self.filepath)
+        self.size = im.size
+
+        rotated = False
+
+        if not self.options.get("auto-orient", False):
+            return
+
+        exif = im.getexif()
+        if not exif:
+            return
+
+        rotated = exif.get(0x0112, 1) in {5, 6, 7, 8}
+        if rotated:
+            self.size = (self.size[1], self.size[0])
 
 
 # TODO: add support for looking into parent directories (name: ../other_gallery/pic.jpg)

--- a/recitale/image.py
+++ b/recitale/image.py
@@ -18,7 +18,7 @@ class ImageCommon:
     @property
     def ratio(self):
         # For when BaseImage.ratio is called before BaseImage.copy() is.
-        if not self.size:
+        if not hasattr(self, "size"):
             self.size = imagesize.get(self.filepath)
         width, height = self.size
         return width / height

--- a/recitale/image.py
+++ b/recitale/image.py
@@ -59,8 +59,11 @@ class BaseImage(ImageCommon):
 
     def copy(self):
         if not self.copysize:
-            width, height = imagesize.get(self.filepath)
+            # No need to get image size if .ratio() was called before .copy()
+            if not hasattr(self, "size"):
+                self.size = imagesize.get(self.filepath)
 
+            width, height = self.size
             if self.resize:
                 match = BaseImage.re_rsz.match(str(self.resize))
                 if not match:

--- a/recitale/recitale.py
+++ b/recitale/recitale.py
@@ -528,7 +528,8 @@ def render_thumbnails(base):
             IGNORE_DIM = 65596
             height = height if height is not None else IGNORE_DIM
             width = width if width is not None else IGNORE_DIM
-            im.thumbnail((width, height), Image.LANCZOS)
+
+        im.thumbnail((width, height), Image.LANCZOS)
 
         logger.debug(
             "(%s) Creating thumbnail %s: size=%s",

--- a/recitale/recitale.py
+++ b/recitale/recitale.py
@@ -682,6 +682,7 @@ def render_video(cache, base):
         return
 
     for thumbnail in uncached:
+        filepath = Path("build") / thumbnail.filepath
         cache.cache_picture(base.filepath, str(filepath), base.options)
 
 

--- a/recitale/recitale.py
+++ b/recitale/recitale.py
@@ -608,11 +608,11 @@ def render_video(cache, base):
             height = height if height else -1
             command = (
                 reencodecmd
-                + "-s "
+                + '-vf "scale='
                 + str(width)
-                + "x"
+                + ":"
                 + str(height)
-                + " "
+                + '" '
                 + shlex.quote(str(filepath))
             )
             command = command.format(**base.options)

--- a/recitale/themes/exposure/templates/index.html
+++ b/recitale/themes/exposure/templates/index.html
@@ -42,7 +42,7 @@
       </a>
       {% if gallery.cover_type == "video" %}
       {% set video = Video.get(gallery.link, gallery.cover) %}
-      {% set vid = video.reencode((1280, 720)) %}
+      {% set vid = video.reencode((None, 900)) %}
       {% set format = settings.ffmpeg.extension %}
       <div class="gallery-cover">
         <video autoplay loop muted class="fillWidth">

--- a/recitale/themes/exposure/templates/sections/bordered-picture.html
+++ b/recitale/themes/exposure/templates/sections/bordered-picture.html
@@ -5,7 +5,7 @@
   {% set video = Video.get(link, section.image) %}
   {% set format = settings.ffmpeg.extension %}
   {% set caption = section.text %}
-  {% set vid = video.reencode((1280, 720)) %}
+  {% set vid = video.reencode((None, 2000)) %}
   <section class="bordered-picture baguette" style="position: relative;">
     <div class="caption">
         <img class="lazy" data-src="{{ video.thumbnail((None, 2000)) }}" src="./../static/img/11-14.svg" alt="">

--- a/recitale/themes/exposure/templates/sections/full-picture.html
+++ b/recitale/themes/exposure/templates/sections/full-picture.html
@@ -1,7 +1,7 @@
 {% if section.image.type == "video" %}
 {% set format = settings.ffmpeg.extension %}
 {% set video = Video.get(link, section.image) %}
-{% set vid = video.reencode((1280, 720)) %}
+{% set vid = video.reencode((None, 2000)) %}
 <section class="full-picture">
   <div class="video-container">
     {% if section.text %}

--- a/recitale/themes/exposure/templates/sections/pictures-group.html
+++ b/recitale/themes/exposure/templates/sections/pictures-group.html
@@ -14,7 +14,7 @@
       {% if image.type == "video" %}
       {% set video = Video.get(link, image) %}
       {% set format = settings.ffmpeg.extension %}
-      {% set vid = video.reencode((1280, 720)) %}
+      {% set vid = video.reencode((None, height)) %}
       {% set ratio = video.ratio %}
       {% else %}
       {% set image = Image.get(link, image) %}
@@ -23,7 +23,7 @@
       <div class="picture caption" style="flex-grow: {{ ratio }}">
         {% if image.type == "video" %}
         <img class="lazy" data-src="{{ video.thumbnail((None, height)) }}" src="./../static/img/11-14.svg" alt="">
-        <video class="lazy" id="{{ vid }}" onclick="goFullscreen('{{ vid }}');" data-src="{{ vid }}" data-poster="{{ video.thumbnail((None, 600)) }}" alt="" loop="loop" preload="none" autoplay muted {% if image.controls %}controls="true"{% endif %}>
+        <video class="lazy" id="{{ vid }}" onclick="goFullscreen('{{ vid }}');" data-src="{{ vid }}" data-poster="{{ video.thumbnail((None, height)) }}" alt="" loop="loop" preload="none" autoplay muted {% if image.controls %}controls="true"{% endif %}>
           <source data-src="{{ vid }}" type="video/{{ format }}">
         </video>
         {% if caption %}

--- a/recitale/themes/exposure/templates/sections/pictures-group.html
+++ b/recitale/themes/exposure/templates/sections/pictures-group.html
@@ -6,6 +6,11 @@
     <div class="pictures-line">
       {% for image in line %}
       {% set caption = image.text %}
+      {% if loop.length == 1 %}
+      {% set height = 1366 %}
+      {% else %}
+      {% set height = 600 %}
+      {% endif %}
       {% if image.type == "video" %}
       {% set video = Video.get(link, image) %}
       {% set format = settings.ffmpeg.extension %}
@@ -17,11 +22,7 @@
       {% endif %}
       <div class="picture caption" style="flex-grow: {{ ratio }}">
         {% if image.type == "video" %}
-        {% if loop.length == 1 %}
-        <img class="lazy" data-src="{{ video.thumbnail((None, 1366)) }}" src="./../static/img/11-14.svg" alt="">
-        {% else %}
-        <img class="lazy" data-src="{{ video.thumbnail((None, 600)) }}" src="./../static/img/11-14.svg" alt="">
-        {% endif %}
+        <img class="lazy" data-src="{{ video.thumbnail((None, height)) }}" src="./../static/img/11-14.svg" alt="">
         <video class="lazy" id="{{ vid }}" onclick="goFullscreen('{{ vid }}');" data-src="{{ vid }}" data-poster="{{ video.thumbnail((None, 600)) }}" alt="" loop="loop" preload="none" autoplay muted {% if image.controls %}controls="true"{% endif %}>
           <source data-src="{{ vid }}" type="video/{{ format }}">
         </video>
@@ -37,11 +38,7 @@
            data-at-1366="{{ image.thumbnail((None, 1366)) }}"
            data-at-1920="{{ image.thumbnail((None, 1920)) }}"
            >
-	{% if loop.length == 1 %}
-           <img class="lazy" src="{% if caption %}./../static/img/11-14.svg{% endif %}" data-src="{{ image.thumbnail((None, 1366)) }}" alt="">
-	{% else %}
-           <img class="lazy" src="{% if caption %}./../static/img/11-14.svg{% endif %}" data-src="{{ image.thumbnail((None, 600)) }}" alt="">
-	{% endif %}
+           <img class="lazy" src="{% if caption %}./../static/img/11-14.svg{% endif %}" data-src="{{ image.thumbnail((None, height)) }}" alt="">
            {% if caption %}
            <div class="caption__overlay">
              <h5 class="caption__overlay__title">{{ caption }}</h5>

--- a/recitale/themes/light/templates/index.html
+++ b/recitale/themes/light/templates/index.html
@@ -36,7 +36,7 @@
       </a>
       {% if gallery.cover_type == "video" %}
       {% set video = Video.get(gallery.link, gallery.cover) %}
-      {% set vid = video.reencode((1280, 720)) %}
+      {% set vid = video.reencode((None, 900)) %}
       {% else %}
       {% set cover = Image.get(gallery.link, gallery.cover) %}
       {% endif %}

--- a/recitale/themes/light/templates/sections/bordered-picture.html
+++ b/recitale/themes/light/templates/sections/bordered-picture.html
@@ -6,7 +6,7 @@
 {% if section.image.type == "video" %}
 {% set video = Video.get(link + "/" + pathstatic, section.image) %}
 {% set format = settings.ffmpeg.extension %}
-{% set vid = video.reencode((1280, 720)) %}
+{% set vid = video.reencode((None, 800)) %}
 {% else %}
 {% set image = Image.get(link + "/" + pathstatic, section.image) %}
 {% endif %}

--- a/recitale/themes/light/templates/sections/full-picture.html
+++ b/recitale/themes/light/templates/sections/full-picture.html
@@ -6,7 +6,7 @@
 {% if section.image.type == "video" %}
 {% set video = Video.get(link + "/" + pathstatic, section.image) %}
 {% set format = settings.ffmpeg.extension %}
-{% set vid = video.reencode((1280, 720)) %}
+{% set vid = video.reencode((None, 800)) %}
 {% else %}
 {% set image = Image.get(link + "/" + pathstatic, section.image) %}
 {% endif %}

--- a/recitale/themes/light/templates/sections/pictures-group.html
+++ b/recitale/themes/light/templates/sections/pictures-group.html
@@ -9,7 +9,7 @@
     {% if image.type == "video" %}
     {% set video = Video.get(link + "/" + pathstatic, image) %}
     {% set format = settings.ffmpeg.extension %}
-    {% set vid = video.reencode((1280, 720)) %}
+    {% set vid = video.reencode((None, 800)) %}
     {% else %}
     {% set image = Image.get(link + "/" + pathstatic, image) %}
     {% endif %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@ jinja2>=2.9
 ruamel.yaml<0.18.0
 pillow>=6
 pycryptodomex
-imagesize
 tqdm

--- a/test/test_image.py
+++ b/test/test_image.py
@@ -4,31 +4,80 @@ from json import dumps as json_dumps
 from unittest.mock import patch
 from zlib import crc32
 
+from PIL import Image
+
 from recitale.image import BaseImage, ImageFactory
 from recitale.utils import remove_superficial_options
 
 
 class TestBaseImage:
-    @patch("recitale.image.imagesize.get", return_value=(200, 300))
-    def test_first_copy_no_resize(self, mock_imgsz):
-        base = BaseImage({"name": "test.jpg"}, {})
-        base.copy()
-        assert base.copysize == (200, 300)
+    @pytest.mark.parametrize("exif", [None, {0x0112: 1}, {0x0112: 5}])
+    @pytest.mark.parametrize("auto_orient", [False, True])
+    @patch("recitale.image.Image.open")
+    def test_first_copy_no_resize(self, mock_imgsz, auto_orient, exif):
+        def mock_exif():
+            return exif
 
-    @patch("recitale.image.imagesize.get", return_value=(200, 300))
+        type(mock_imgsz.return_value).size = (200, 400)
+        mock_imgsz.return_value.getexif.side_effect = mock_exif
+
+        base = BaseImage({"name": "test.jpg"}, {"auto-orient": auto_orient})
+        base.copy()
+        ratio = base.ratio
+
+        # .ratio should have not called Image.open() again
+        mock_imgsz.assert_called_once()
+
+        if not auto_orient:
+            mock_imgsz.return_value.getexif.assert_not_called()
+            assert base.size == (200, 400)
+            assert base.copysize == (200, 400)
+            assert ratio == 200 / 400
+            return
+
+        mock_imgsz.return_value.getexif.assert_called_once()
+        if exif and exif.get(0x112, 1) == 5:
+            assert base.size == (400, 200)
+            assert base.copysize == (400, 200)
+            assert ratio == 400 / 200
+            return
+
+        assert base.size == (200, 400)
+        assert base.copysize == (200, 400)
+        assert ratio == 200 / 400
+
+    @patch("recitale.image.Image.open")
+    def test_ratio_first(self, mock_imgsz):
+        type(mock_imgsz.return_value).size = (200, 400)
+
+        base = BaseImage({"name": "test.jpg"}, {"auto-orient": False})
+        ratio = base.ratio
+        mock_imgsz.return_value.getexif.assert_not_called()
+        assert base.size == (200, 400)
+        assert ratio == 200 / 400
+
+        mock_imgsz.reset_mock()
+
+        base.copy()
+
+        # BaseImage.copy() shouldn't need to inspect the file after .ratio
+        mock_imgsz.assert_not_called()
+
+    @patch("recitale.image.Image.open", return_value=Image.new("L", (200, 300)))
     def test_two_copies_no_resize(self, mock_imgsz):
         base = BaseImage({"name": "test.jpg"}, {})
         base.copy()
         base.copy()
         assert len(base.thumbnails.keys()) == 1
 
-    @patch("recitale.image.imagesize.get", return_value=(200, 300))
+    @patch("recitale.image.Image.open", return_value=Image.new("L", (200, 300)))
     def test_copy_resize(self, mock_imgsz):
         base = BaseImage({"name": "test.jpg", "resize": "50%"}, {})
         base.copy()
+        assert base.size == (200, 300)
         assert base.copysize == (100, 150)
 
-    @patch("recitale.image.imagesize.get", return_value=(200, 300))
+    @patch("recitale.image.Image.open", return_value=Image.new("L", (200, 300)))
     def test_copy_filepath(self, mock_imgsz):
         base = BaseImage({"name": "test.jpg", "resize": "50%"}, {})
         copy = base.copy()
@@ -40,7 +89,7 @@ class TestBaseImage:
         "recitale.image.remove_superficial_options",
         side_effect=remove_superficial_options,
     )
-    @patch("recitale.image.imagesize.get", return_value=(200, 300))
+    @patch("recitale.image.Image.open", return_value=Image.new("L", (200, 300)))
     def test_copy_filepath_remove_superficial_options(
         self, mock_imgsz, mock_rm_sup_opt
     ):
@@ -53,7 +102,7 @@ class TestBaseImage:
             crc32(bytes(json_dumps({"test": "test123"}, sort_keys=True), "utf-8"))
         )
 
-    @patch("recitale.image.imagesize.get", return_value=(200, 300))
+    @patch("recitale.image.Image.open", return_value=Image.new("L", (200, 300)))
     def test_copy_invalid_resize(self, mock_imgsz, caplog):
         base = BaseImage({"name": "test.jpg", "resize": "50"}, {})
         with pytest.raises(SystemExit) as sysexit:


### PR DESCRIPTION
This is a collection of various fixes:
- flex layout was broken if mixing images and videos on a single line because .ratio() for images would always return nothing and a video would return the proper ratio,
- Image.copy() did not respect the `resize` parameter,
- Image.ratio() did not respect the orientation set in the EXIF metadata. `imagesize` supports it in v2+ but there's no benefit over doing it with pillow anymore, thus it is dropped and orientation is now respected (but takes longer per picture),
- All but the last thumbnail for a video are now properly cached (the last thumbnail as properly cached already),
- All videos were reencoded in 1280x720 regardless of their original ratio or orientation, we now respect the ratio (ffmpeg handles the orientation by itself already),